### PR TITLE
add IdlOnlyTypes - even though they are commented out atm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,10 @@ set(action_files
   "action/Fibonacci.action"
 )
 
+set(idl_files
+  # "idl/IdlOnlyTypes.idl"
+)
+
 set(interface_install_dir "share/${PROJECT_NAME}")
 
 install(
@@ -40,6 +44,10 @@ install(
 install(
   FILES ${action_files}
   DESTINATION ${interface_install_dir}/action
+)
+install(
+  FILES ${idl_files}
+  DESTINATION ${interface_install_dir}/idl
 )
 
 ament_package(

--- a/idl/IdlOnlyTypes.idl
+++ b/idl/IdlOnlyTypes.idl
@@ -1,0 +1,8 @@
+module test_msgs {
+  module idl {
+    struct IdlOnlyTypes {
+      wchar wchar_value;
+      long double long_double_value;
+    };
+  };
+};

--- a/test_interface_files-extras.cmake.in
+++ b/test_interface_files-extras.cmake.in
@@ -29,3 +29,8 @@ foreach(action @action_files@)
   list(APPEND @PROJECT_NAME@_ACTION_FILES
     "@CMAKE_INSTALL_PREFIX@/@interface_install_dir@:${action}")
 endforeach()
+set(@PROJECT_NAME@_IDL_FILES "")
+foreach(idl @idl_files@)
+  list(APPEND @PROJECT_NAME@_IDL_FILES
+    "@CMAKE_INSTALL_PREFIX@/@interface_install_dir@:${idl}")
+endforeach()


### PR DESCRIPTION
Related to ros2/rosidl#383.

This was mostly used to test `long double` and `wchar` types with FastRTPS. Until the other RMW impl. support this (ros2/rosidl_typesupport_connext#33, ros2/rosidl_typesupport_opensplice#31) the `.idl` file is commented out.

So currently this is a no-op but it allows to easily enable the file for testing in the future.