### PR TITLE
 add wstring default values with non-ASCII characters

### DIFF
--- a/msg/WStrings.msg
+++ b/msg/WStrings.msg
@@ -1,7 +1,7 @@
 wstring wstring_value
 wstring wstring_value_default1 "Hello world!"
-#wstring wstring_value_default2 "Hellö wörld!"
-#wstring wstring_value_default3 "ハローワールド"
+wstring wstring_value_default2 "Hellö wörld!"
+wstring wstring_value_default3 "ハローワールド"
 #wstring WSTRING_CONST="Hello world!"
 #wstring<=22 bounded_wstring_value
 #wstring<=22 bounded_wstring_value_default1 "Hello world!"

--- a/msg/WStrings.msg
+++ b/msg/WStrings.msg
@@ -1,5 +1,5 @@
 wstring wstring_value
-#wstring wstring_value_default1 "Hello world!"
+wstring wstring_value_default1 "Hello world!"
 #wstring wstring_value_default2 "Hellö wörld!"
 #wstring wstring_value_default3 "ハローワールド"
 #wstring WSTRING_CONST="Hello world!"


### PR DESCRIPTION
The first commit only enables a field with an ASCII default value. That passes on Windows already: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7436)](https://ci.ros2.org/job/ci_windows/7436/)

The second commit enables fields with non-ASCII default values.
* That fails on Windows: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7437)](https://ci.ros2.org/job/ci_windows/7437/)
* On Linux this passes just fine: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7616)](https://ci.ros2.org/job/ci_linux/7616/)