### PR TITLE
Add not working idl examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(msg_files
   "msg/Defaults.msg"
   "msg/Empty.msg"
   "msg/MultiNested.msg"
+  "msg/MyMessage.idl"
   "msg/Nested.msg"
   "msg/Strings.msg"
   "msg/UnboundedSequences.msg"
@@ -22,14 +23,16 @@ set(srv_files
   "srv/Arrays.srv"
   "srv/BasicTypes.srv"
   "srv/Empty.srv"
+  "srv/MyService.idl"
 )
 
 set(action_files
   "action/Fibonacci.action"
+  "action/MyAction.idl"
 )
 
 set(idl_files
-  # "idl/IdlOnlyTypes.idl"
+  "idl/IdlOnlyTypes.idl"
 )
 
 set(interface_install_dir "share/${PROJECT_NAME}")

--- a/action/MyAction.idl
+++ b/action/MyAction.idl
@@ -1,0 +1,22 @@
+module rosidl_parser {
+  module action {
+    module MyAction_Goal_Constants {
+      const short SHORT_CONSTANT = -23;
+    };
+    struct MyAction_Goal {
+      int32 input_value;
+    };
+    module MyAction_Result_Constants {
+      const unsigned long UNSIGNED_LONG_CONSTANT = 42;
+    };
+    struct MyAction_Result {
+      uint32 output_value;
+    };
+    module MyAction_Feedback_Constants {
+      const float FLOAT_CONSTANT = 1.25;
+    };
+    struct MyAction_Feedback {
+      float progress_value;
+    };
+  };
+};

--- a/action/MyAction.idl
+++ b/action/MyAction.idl
@@ -1,4 +1,4 @@
-module rosidl_parser {
+module test_msgs {
   module action {
     module MyAction_Goal_Constants {
       const short SHORT_CONSTANT = -23;

--- a/msg/MyMessage.idl
+++ b/msg/MyMessage.idl
@@ -1,0 +1,50 @@
+module rosidl_parser {
+  module msg {
+    module MyMessage_Constants {
+      const short SHORT_CONSTANT = -23;
+      const unsigned long UNSIGNED_LONG_CONSTANT = 42;
+      const float FLOAT_CONSTANT = 1.25;
+      const boolean BOOLEAN_CONSTANT = TRUE;
+      const string STRING_CONSTANT = "string_value";
+      const wstring WSTRING_CONSTANT = "wstring_value_\u2122";
+    };
+
+    @verbatim ( language="comment", text="Documentation of MyMessage." )
+    struct MyMessage {
+      short short_value, short_value2;
+      @default ( value=123 )
+      unsigned short unsigned_short_value;
+      @key
+      @range ( min=-10, max=10 )
+      long long_value;
+      unsigned long unsigned_long_value;
+      long long long_long_value;
+      unsigned long long unsigned_long_long_value;
+      float float_value;
+      double double_value;
+      long double long_double_value;
+      char char_value;
+      wchar wchar_value;
+      boolean boolean_value;
+      octet octet_value;
+      int8 int8_value;
+      uint8 uint8_value;
+      int16 int16_value;
+      uint16 uint16_value;
+      int32 int32_value;
+      uint32 uint32_value;
+      int64 int64_value;
+      uint64 uint64_value;
+      string string_value;
+      string<5> bounded_string_value;
+      wstring wstring_value;
+      wstring<23> bounded_wstring_value;
+      wstring<UNSIGNED_LONG_CONSTANT> constant_bounded_wstring_value;
+      sequence<short> unbounded_short_values;
+      sequence<short, 5> bounded_short_values;
+      sequence<string<3>> unbounded_values_of_bounded_strings;
+      sequence<string<3>, 4> bounded_values_of_bounded_strings;
+      short array_short_values[23];
+    };
+  };
+};

--- a/msg/MyMessage.idl
+++ b/msg/MyMessage.idl
@@ -1,4 +1,4 @@
-module rosidl_parser {
+module test_msgs {
   module msg {
     module MyMessage_Constants {
       const short SHORT_CONSTANT = -23;

--- a/srv/MyService.idl
+++ b/srv/MyService.idl
@@ -1,0 +1,17 @@
+module rosidl_parser {
+  module srv {
+    module MyService_Request_Constants {
+      const short SHORT_CONSTANT = -23;
+    };
+    struct MyService_Request {
+      short short_value;
+      string string_value;
+    };
+    module MyService_Response_Constants {
+      const unsigned long UNSIGNED_LONG_CONSTANT = 42;
+    };
+    struct MyService_Response {
+      boolean boolean_value;
+    };
+  };
+};

--- a/srv/MyService.idl
+++ b/srv/MyService.idl
@@ -1,4 +1,4 @@
-module rosidl_parser {
+module test_msgs {
   module srv {
     module MyService_Request_Constants {
       const short SHORT_CONSTANT = -23;


### PR DESCRIPTION
I copied some idl examples from https://github.com/ros2/rosidl/blob/4b31e72cd7ce5b7e5b7f110472b063365e677132/rosidl_parser/test/, and added them to the lists here.

Interfaces are generated when [building test_msgs](https://github.com/ros2/rcl_interfaces/blob/a7ea280423e64f38d910e318d73a55bc22e71d42/test_msgs/CMakeLists.txt#L23-L32):
```
colcon build --symlink-install --packages-up-to test_msgs
```

I have build errors when I left any of the `.idl` files uncommented.