### PR TITLE
Add basic warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,14 @@ cmake_minimum_required(VERSION 3.5)
 
 project(test_interface_files NONE)
 
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
 find_package(ament_cmake_core REQUIRED)
 
 set(msg_files


### PR DESCRIPTION
This PR enables `-Wall`, `-Wextra`, and `-Wpedantic`. No warnings were thrown by adding this.