### PR TITLE
Revert "Update package.xml"

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,11 +14,6 @@
   <author email="karsten@openrobotics.org">Karsten Knese</author>
 
   <buildtool_depend>ament_cmake_core</buildtool_depend>
-  <buildtool_depend>rosidl_default_generators</buildtool_depend>
-
-  <exec_depend>rosidl_default_runtime</exec_depend>
-
-  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Reverts ros2/test_interface_files#18

With this in place, we can't build at all right now.  Reverting seems to fix that.