### PR TITLE
Drop long double from the IDL.

### DIFF
--- a/idl/IdlOnlyTypes.idl
+++ b/idl/IdlOnlyTypes.idl
@@ -2,7 +2,6 @@ module test_msgs {
   module idl {
     struct IdlOnlyTypes {
       wchar wchar_value;
-      long double long_double_value;
     };
   };
 };


### PR DESCRIPTION
See https://github.com/ros2/rosidl_dynamic_typesupport/issues/11 for the reasons why we want to do this.