### PR TITLE
Add default strings with escaped characters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(msg_files
   "msg/BasicTypes.msg"
   "msg/BoundedPlainSequences.msg"
   "msg/BoundedSequences.msg"
+  "msg/Comments.msg"
   "msg/Constants.msg"
   "msg/Defaults.msg"
   "msg/Empty.msg"

--- a/msg/Comments.msg
+++ b/msg/Comments.msg
@@ -1,0 +1,12 @@
+# Normal comment
+uint8 value1
+
+# 	Tab
+uint8 value2
+
+# Not a tab \t
+uint8 value3
+
+# Not a newline (TODO: Doesn't work now)
+uint8 value4
+

--- a/msg/Strings.msg
+++ b/msg/Strings.msg
@@ -4,6 +4,9 @@ string string_value_default2 "Hello'world!"
 string string_value_default3 'Hello"world!'
 string string_value_default4 'Hello\'world!'
 string string_value_default5 "Hello\"world!"
+string string_value_default6 "Hello\\world!"
+string string_value_default7 "Hello\tworld!"
+# TODO: Add new line
 string STRING_CONST="Hello world!"
 string<=22 bounded_string_value
 string<=22 bounded_string_value_default1 "Hello world!"
@@ -11,3 +14,6 @@ string<=22 bounded_string_value_default2 "Hello'world!"
 string<=22 bounded_string_value_default3 'Hello"world!'
 string<=22 bounded_string_value_default4 'Hello\'world!'
 string<=22 bounded_string_value_default5 "Hello\"world!"
+string<=22 bounded_string_value_default6 "Hello\\world!"
+string<=22 bounded_string_value_default7 "Hello\tworld!"
+# TODO: Add new line

--- a/msg/WStrings.msg
+++ b/msg/WStrings.msg
@@ -2,6 +2,7 @@ wstring wstring_value
 wstring wstring_value_default1 "Hello world!"
 wstring wstring_value_default2 "Hellö wörld!"
 wstring wstring_value_default3 "ハローワールド"
+wstring wstring_value_default4 "Hell\xc3\xb6 w\xc3\xb6rld!"
 #wstring WSTRING_CONST="Hello world!"
 #wstring<=22 bounded_wstring_value
 #wstring<=22 bounded_wstring_value_default1 "Hello world!"


### PR DESCRIPTION
This PR adds default strings containing escaped characters.

Related to: https://github.com/ros2/rosidl/issues/855